### PR TITLE
fix: 投稿作成時にprefectureデータのnullを許容するように変更

### DIFF
--- a/db/migrate/20230129031038_change_prefecture_to_allow_null.rb
+++ b/db/migrate/20230129031038_change_prefecture_to_allow_null.rb
@@ -1,0 +1,9 @@
+class ChangePrefectureToAllowNull < ActiveRecord::Migration[7.0]
+  def up
+    change_column_null :books, :prefecture_id, true
+  end
+
+  def down
+    change_column_null :books, :prefecture_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_29_002200) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_29_031038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,7 +42,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_29_002200) do
     t.text "info_link"
     t.string "published_date"
     t.bigint "country_id", null: false
-    t.bigint "prefecture_id", null: false
+    t.bigint "prefecture_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false


### PR DESCRIPTION
投稿作成時にBooksテーブルのprefecture_idのnullを許容していなかったが、許容するように変更した。