### PR TITLE
add: プロフィール詳細、編集機能の作成

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,26 @@
+class ProfilesController < ApplicationController
+  before_action :set_user
+  
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to profile_path, success: t('defaults.message.updated', item: User.model_name.human)
+    else
+      flash.now['danger'] = t('defaults.message.not_updated', item: User.model_name.human)
+      render :edit
+    end
+  end
+
+  def show; end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+
+  def user_params
+    params.require(:user).permit(:email, :name, :avatar, :avatar_cache)
+  end
+end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for(:title, t('.title')) %>
+<%# breadcrumb :profile_edit %>
+<div class="flex items-center justify-center p-12">
+  <div class="bg-white card w-1/2 border text-primary m-3">
+    <div class="card-body">
+      <div class="flex items-center justify-center p-12">
+        <div class="form-control w-4/5 max-w-2xl">
+          <%= form_with model: @user, url: profile_path, local: true do |f| %>
+            <%= render 'shared/error_messages', object: f.object %>   
+            <%= f.label :avatar, class: "label" %>
+            <%= f.file_field :avatar %>
+            <%= f.hidden_field :avatar_cache %>
+            <%= f.label :name, class: "label" %>
+            <%= f.text_field :name, class: "input input-bordered w-full" %>
+            <%# if @user.role != 'guest' %>
+              <%= f.label :email, class: "label" %>
+              <%= f.text_field :email, class: "input input-bordered w-full" %>
+            <%# end %>
+            <div class="py-4">
+              <%= f.submit t('.save'), class: "btn text-secondary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,28 @@
+<% content_for(:title, t('.title')) %>
+<%# breadcrumb :profile %>
+<div class="flex items-center justify-center p-12">
+  <div class="bg-white card w-1/2 border text-primary m-3">
+    <div class="card-body">
+      <div class="flex items-center justify-center p-6">
+        <div class="form-control w-4/5 max-w-2xl">
+          <p class="text-center text-xl pb-6"><%= t '.title' %></p>
+          <div class="lg:flex">
+            <div class="place-self-center">
+              <%= image_tag current_user.avatar.url, class: 'rounded-full', size: '100x100' %>
+            </div>
+            <div class="flex flex-col justify-between py-6 pl-6">
+              <p>ユーザー名: <%= current_user.name %></p>
+              <%# if current_user.role != 'guest' %>
+                <p>メールアドレス: <%= current_user.email %></p>
+              <%# end %>
+            </div>
+          </div>
+          <%= link_to edit_profile_path do %>
+            <i class="ml-5 pt-10 fa-solid fa-pen-to-square fa-lg"></i>
+          <% end %>
+        </div>
+      </div>
+      <%#= link_to "ブックマーク一覧", bookmarks_books_path, { class: "bg-neutral hover:bg-accent text-secondary text-center font-bold py-2 px-3 mb-3 border rounded" }%>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,7 +11,7 @@
         <% end %>
         <li><%= link_to t('menu.index'), books_path %></li>
         <li><%= link_to t('menu.post'), search_books_path %></li>
-        <!--li><%#= link_to t('profiles.show.title'), profile_path, class: 'dropdown-item' %></li-->
+        <li><%= link_to t('profiles.show.title'), profile_path, class: 'dropdown-item' %></li>
         <% if logged_in? %>
           <li><%= button_to "ログアウト", logout_path, method: :delete %></li>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
       get :search
     end
   end
+  resource :profile, only: %i[show edit update]
 end


### PR DESCRIPTION
ヘッダーからプロフィールの詳細画面に遷移できるようにした。
また、詳細画面から編集画面に遷移し、アバター、メールアドレス、ユーザー名を変更できるようにした。