### PR TITLE
add: ゲストログイン機能の作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  before_action :require_login
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,6 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :require_login, only: %i[top terms privacy]
+
   def top; end
 
   def terms; end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,6 @@
 class UserSessionsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create guest_login]
+
   def new; end
 
   def create
@@ -14,5 +16,20 @@ class UserSessionsController < ApplicationController
   def destroy
     logout
     redirect_to(root_path, notice: 'ログアウトしました')
+  end
+
+  def guest_login
+    rondom_value = SecureRandom.alphanumeric(10) + Time.zone.now.to_i.to_s
+    @guest_user = User.create(
+      name: 'GuestUser',
+      email: rondom_value + '@example.com',
+      password: 'password',
+      password_confirmation: 'password',
+      role: :guest
+    )
+    id = @guest_user.id
+    @guest_user.update!(name: "GuestUser_#{id}")
+    auto_login(@guest_user)
+    redirect_back_or_to books_path, success: 'ゲストとしてログインしました'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
   def new
     @user = User.new
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true, length: { maximum: 50 }
 
+  enum role: { general: 0, admin: 1, guest: 2 }
+
   def own?(object)
     id == object.user_id
   end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -12,10 +12,10 @@
             <%= f.hidden_field :avatar_cache %>
             <%= f.label :name, class: "label" %>
             <%= f.text_field :name, class: "input input-bordered w-full" %>
-            <%# if @user.role != 'guest' %>
+            <% if @user.role != 'guest' %>
               <%= f.label :email, class: "label" %>
               <%= f.text_field :email, class: "input input-bordered w-full" %>
-            <%# end %>
+            <% end %>
             <div class="py-4">
               <%= f.submit t('.save'), class: "btn text-secondary" %>
             </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -12,9 +12,9 @@
             </div>
             <div class="flex flex-col justify-between py-6 pl-6">
               <p>ユーザー名: <%= current_user.name %></p>
-              <%# if current_user.role != 'guest' %>
+              <% if current_user.role != 'guest' %>
                 <p>メールアドレス: <%= current_user.email %></p>
-              <%# end %>
+              <% end %>
             </div>
           </div>
           <%= link_to edit_profile_path do %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -22,12 +22,12 @@
           <p>自分のお気に入りの作品とその舞台を紐づけて投稿することができます。</p>
         </div>
       </div>
-      <%# unless logged_in? %>
-        <button class="btn my-12 text-secondary"><%#= link_to '早速はじめてみる（登録ページへ）', new_user_path %></button>
+      <% unless logged_in? %>
+        <button class="btn my-12 text-secondary"><%= link_to '早速はじめてみる（登録ページへ）', new_user_path %></button>
         <div>
-          <%#= button_to 'ゲストログインしてはじめてみる', guest_login_path, class: 'btn w-100 text-secondary' %>
+          <%= button_to 'ゲストログインしてはじめてみる', guest_login_path, class: 'btn w-100 text-secondary' %>
         </div>
-      <%# end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:itle, t('.title')) %>
+<% content_for(:title, t('.title')) %>
 <div class="flex items-center justify-center py-5 px-4">
   <div class="mx-auto w-full max-w-2xl">
     <div class="text-center text-2xl font-bold text-primary pb-3"><%= t('.title') %></div>
@@ -15,6 +15,12 @@
       </div>
       <div class="bg-white card border-2 px-8 pt-8 pb-3 rounded-lg">
         <p class="font-bold mb-4 pb-2 text-center text-primary">アカウントをお持ちでない方へ</p>
+        <div class="mb-5">
+          <p class="mb-2 text-center fs-3 text-primary">ゲストユーザとしてログインする</p>
+          <div class="flex justify-center">
+            <%= button_to 'ゲストログイン', guest_login_path, class: 'btn w-100 text-secondary' %>
+          </div>
+        </div>
         <div class="mb-4">
           <p class="mb-2 fs-3 text-center text-primary">新しくアカウントを作成する</p>
           <div class="flex justify-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
+  post '/guest_login', to: 'user_sessions#guest_login'
   resources :users, only: %i[new create]
   resources :books do
     collection do

--- a/db/migrate/20230129070333_add_role_to_users.rb
+++ b/db/migrate/20230129070333_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_29_041828) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_29_070333) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -85,6 +85,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_29_041828) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
enumを設定して、general: 0, admin: 1, guest: 2のロールを作成した。
ゲストログイン機能を作成し、ゲストユーザーはプロフィールのメールアドレスの確認と編集以外の機能を使用できるようにした。