### PR TITLE
fix: アップロード画像の保存場所を本番ではS3に変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@
 
 /public/uploads
 .DS_Store
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,10 @@ gem 'kaminari'
 gem 'gretel'
 #投稿検索
 gem 'ransack'
+#アップロード画像の保存
+gem 'fog-aws'
+#環境変数の管理
+gem 'dotenv-rails'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,12 +91,33 @@ GEM
     debug (1.7.1)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
+    excon (0.98.0)
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
+    fog-aws (3.16.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.3.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     gretel (4.4.0)
@@ -139,10 +160,14 @@ GEM
       net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.17.0)
     msgpack (1.6.0)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     net-imap (0.3.4)
       date
@@ -269,7 +294,9 @@ DEPENDENCIES
   carrierwave
   cssbundling-rails
   debug
+  dotenv-rails
   faraday
+  fog-aws
   gretel
   jbuilder
   jsbundling-rails

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -4,8 +4,12 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  #storage :file
+  if Rails.env.production?
+    storage :fog # 本番環境のみ
+  else
+    storage :file # 本番環境以外
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/book_image_uploader.rb
+++ b/app/uploaders/book_image_uploader.rb
@@ -4,8 +4,12 @@ class BookImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  #storage :file
+  if Rails.env.production?
+    storage :fog # 本番環境のみ
+  else
+    storage :file # 本番環境以外
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,16 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'hontobutai' # 作成したバケット名を記述
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # 環境変数
+      region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
+      path_style: true
+    }
+end


### PR DESCRIPTION
[gem 'fog-aws'](https://github.com/fog/fog-aws)と[gem 'dotenv-rails'](https://github.com/bkeepers/dotenv)を使用し、ユーザーのアバター画像と本の画像の保存場所をfileからAWSのS3に変更した。