### PR TITLE
fix: 本番のS3設定の修正

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,6 +3,9 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
+  if Rails.env.development? || Rails.env.test? #開発とテストは今まで通りに
+    config.storage = :file
+  elsif Rails.env.production? #本番はS3に保存する
     config.storage :fog
     config.fog_provider = 'fog/aws'
     config.fog_directory  = 'hontobutai' # 作成したバケット名を記述
@@ -13,4 +16,5 @@ CarrierWave.configure do |config|
       region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
       path_style: true
     }
+  end
 end


### PR DESCRIPTION
本番環境でapplicationログに以下のエラーが出たため、
```
/hontobutai2/vendor/bundle/ruby/3.1.0/gems/fog-core-2.3.0/lib/fog/core/service.rb:244:in `validate_options': Missing required arguments: aws_access_key_id, aws_secret_access_key (ArgumentError)
```
[こちら](https://qiita.com/suzy1031/items/ec6827130119874d3b54)の記事を元にcarrierwave.rbの設定を修正した。