### PR TITLE
fix: 環境ごとに画像の保存先を変更

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -5,11 +5,11 @@ class AvatarUploader < CarrierWave::Uploader::Base
 
   # Choose what kind of storage to use for this uploader:
   #storage :file
-  if Rails.env.production?
+  #if Rails.env.production?
     storage :fog # 本番環境のみ
-  else
-    storage :file # 本番環境以外
-  end
+  #else
+  #  storage :file # 本番環境以外
+  #end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/book_image_uploader.rb
+++ b/app/uploaders/book_image_uploader.rb
@@ -5,16 +5,23 @@ class BookImageUploader < CarrierWave::Uploader::Base
 
   # Choose what kind of storage to use for this uploader:
   #storage :file
-  if Rails.env.production?
+  #if Rails.env.production?
     storage :fog # 本番環境のみ
-  else
-    storage :file # 本番環境以外
-  end
+  #else
+  #  storage :file # 本番環境以外
+  #end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+  def store_dir
+    if Rails.env.production?
+      "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    else
+      "uploads/#{Rails.env}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    end
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,9 +3,9 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  if Rails.env.development? || Rails.env.test? #開発とテストは今まで通りに
-    config.storage = :file
-  elsif Rails.env.production? #本番はS3に保存する
+  #if Rails.env.development? || Rails.env.test? #開発とテストは今まで通りに
+  #  config.storage = :file
+  #elsif Rails.env.production? #本番はS3に保存する
     config.storage :fog
     config.fog_provider = 'fog/aws'
     config.fog_directory  = 'hontobutai' # 作成したバケット名を記述
@@ -16,5 +16,5 @@ CarrierWave.configure do |config|
       region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
       path_style: true
     }
-  end
+  #end
 end


### PR DESCRIPTION
アバター画像と本の画像のS3での保存フォルダを、環境ごとに分けた。