### PR TITLE
fix: デバッグのためbin/devとbin/rails sを分けた

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: unset PORT && bin/rails server
+#web: unset PORT && bin/rails server
 js: yarn build --watch
 css: yarn build:css --watch


### PR DESCRIPTION
サーバーの起動にはbin/devを使用していたが、binding.pryでデバッグできないため、Procfile.devを編集し、
・bin/devによるtailwind cssの起動
・bin/rails sによる起動
の2つに分けた。