### PR TITLE
fix: 他人にブックマークされた投稿も削除できるよう修正

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -7,6 +7,7 @@ class Book < ApplicationRecord
   has_many :users, through: :user_books
   has_many :book_authors, dependent: :destroy
   has_many :authors, through: :book_authors
+  has_many :bookmarks, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 100 }
   validates :body, presence: true, length: { minimum: 5 }


### PR DESCRIPTION
他のユーザーにブックマークされている作品は削除できない仕組みになっていたため、
bookモデルに以下の記述を追加し、ブックマークごと削除できるように変更した。
```
has_many :bookmarks, dependent: :destroy
```