### PR TITLE
fix: 地域情報の修正

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,12 +6,13 @@ CarrierWave.configure do |config|
   config.storage :fog
   config.fog_provider = 'fog/aws'
   config.fog_directory  = 'hontobutai3' # 作成したバケット名を記述
+  config.asset_host = 'https://s3.amazonaws.com/hontobutai3'
   config.fog_public = false
   config.fog_credentials = {
     provider: 'AWS',
     aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数
     aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # 環境変数
-    region: 'ap-northeast-1',
+    region: 'us-east-1',
     path_style: true
   }
 end


### PR DESCRIPTION
AWS上で地域情報がus-east-1となっていたため、carrierwave.rbも修正した。