### PR TITLE
fix: 地域の設定を元に戻した

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -12,7 +12,7 @@ CarrierWave.configure do |config|
     provider: 'AWS',
     aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数
     aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # 環境変数
-    region: 'us-east-1',
+    region: 'ap-northeast-1',
     path_style: true
   }
 end


### PR DESCRIPTION
[こちらの記事]()には地域情報はバケット作成時のものを登録するようにあったため、ap-northeast-1に戻した。