### PR TITLE
fix: セレクトボックス間に入る余分なスペースを削除

### DIFF
--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -21,16 +21,16 @@
         <%= f.text_area :body, class: 'block w-1/2 rounded-md border border-gray-300 p-2', rows: 5, placeholder: '5文字以上で入力してください' %>
       </div>
       <div class="mb-3 font-semibold text-primary"><p>本の舞台を選択してください</p></div>
-      <div>
-        <%= f.collection_select :area_id, Area.all, :id, :name, { include_blank: "エリアを選択" }, class: 'border border-gray-300 rounded-md p-2 mb-3' %>
+      <div class="flex flex-col">
+        <%= f.collection_select :area_id, Area.all, :id, :name, { include_blank: "エリアを選択" }, class: 'border border-gray-300 rounded-md w-40 p-2 mb-3' %>
       </div>
       <div>
-        <%= f.select :country_id, [], { include_blank: "国を選択" }, class: 'border border-gray-300 rounded-md p-2' %>
+        <%= f.select :country_id, [], { include_blank: "国を選択" }, class: 'border border-gray-300 w-40 rounded-md p-2' %>
       </div>
       <div class="mb-3">
         <% Area.all.each do |area| %>
-          <template id="country-of-area<%= area.id %>"><br>
-            <%= f.collection_select :country_id, area.countries, :id, :name, { include_blank: "国を選択" }, class: 'border border-gray-300 rounded-md p-2' %>
+          <template id="country-of-area<%= area.id %>">
+            <%= f.collection_select :country_id, area.countries, :id, :name, { include_blank: "国を選択" }, class: 'border border-gray-300 w-40 rounded-md p-2' %>
           </template>
         <% end %>
       </div>


### PR DESCRIPTION
投稿作成画面のareaとcountryのセレクトボックスの間に空白が入っていたため、除去した。