### PR TITLE
fix: コメントの表示文字数の修正

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -10,7 +10,7 @@ class Book < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 100 }
-  validates :body, presence: true, length: { minimum: 5 }
+  validates :body, presence: true, length: { in: 5..200 }
   validates :user_id, presence: true
   validates :country_id, presence: true
   validates :prefecture_id, length: { maximum: 2 }, allow_blank: true

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -11,7 +11,7 @@
       <div class="card-body text-primary">
         <p class="card-text font-bold flex justify-center">著者: <%= @book.authors.pluck(:name).join(', ')&.truncate(20) %></p>
         <p class="card-text flex justify-center">出版日: <%= @book.published_date %></p>
-        <p class="card-text flex justify-center">舞台</p>
+        <p class="card-text flex justify-center">--舞台--</p>
         <p class="card-text flex justify-center"><%= @area[@book.country.area_id - 1] %></p>
         <p class="card-text flex justify-center"><%= @book.country.name %></p>
         <% if @book.prefecture.present? %>
@@ -19,8 +19,11 @@
         <% end %>
         <div class="flex border-top my-3 flex justify-center">
           <div class="flex items-center">
-            <%= image_tag @book.user.avatar_url, class: 'w-12 h-12 rounded-full mr-3 flex justify-center', size: '50x50' %><%= @book.user.name %><p class="card-text px-2">: <%= @book.body.truncate(100) %></p>
+            <%= image_tag @book.user.avatar_url, class: 'w-12 h-12 rounded-full mr-3 flex justify-center', size: '50x50' %><%= @book.user.name %><br>
           </div>
+        </div>
+        <div class="mx-auto">
+          <p class="card-text"><%= @book.body.truncate(200) %></p><br>
         </div>
         <%= link_to '一覧に戻る', books_path, { class: "bg-neutral hover:bg-accent text-secondary text-center font-bold mt-2 py-2 px-3 border rounded" } %>
       </div>


### PR DESCRIPTION
投稿詳細画面でコメントの表示を100文字にしていたが、200文字に変更した。
また、bookモデルでは最低文字数のバリデーションしか作成していなかったため、上限を200文字に設定した。