### PR TITLE
add: お問い合わせフォームの作成

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="grid grid-flow-col gap-4 text-secondary">
     <%= link_to '利用規約', terms_path, class: "link link-hover" %>
     <%= link_to 'プライバシーポリシー', privacy_path, class: "link link-hover" %>
-    <%= link_to 'お問い合わせ', class: "link link-hover" %>
+    <%= link_to 'お問い合わせ', 'https://forms.gle/pPXN8yacJMMjSL4A7', class: "link link-hover" %>
   </div> 
   <div class="text-secondary">
     <p>Copyright © 2023 - All right reserved</p>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -54,7 +54,7 @@
   <div class="p-8 md:w-4/5">
     <h2 class="text-xl font-bold py-4">お問い合わせ</h2>
     <p>お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、以下のお問い合わせフォームまでご連絡ください。</p>
-    <p class="py-2"><%= link_to 'お問い合わせフォーム', '' , class: "link"%></p>
+    <p class="py-2"><%= link_to 'お問い合わせフォーム', 'https://forms.gle/pPXN8yacJMMjSL4A7' , class: "link"%></p>
   </div>
   <div class="p-8 md:w-4/5">
     <h2 class="text-end">以上</h2>


### PR DESCRIPTION
[こちらの記事](https://souken-blog.com/2019/05/28/gogle-form/)を参考に、Googleのお問い合わせフォームを作成し、フッターとプライバシーポリシーページから遷移できるようにした。