### PR TITLE
fix: メイン機能への導線をヘッダーに入れた

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,21 +1,40 @@
-<div class="navbar bg-neutral">
-  <div class="dropdown" id="header-avatar">
-    <div class="flex-none">
-      <label tabindex="0" class="btn btn-square btn-ghost text-white">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
-      </label>
-      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+<header>
+  <div class="navbar bg-neutral text-secondary">
+    <div class="navbar-start">
+      <%= link_to (t 'defaults.top'), root_path, class: "btn btn-ghost normal-case text-xl text-secondary" %>
+    </div>
+    <div class="navbar-end">
+      <div class="dropdown dropdown-end">
+        <label tabindex="0" class="btn btn-square btn-ghost lg:hidden">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+        </label>
+        <ul tabindex="0" class="menu menu-conpact dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 text-left">
+          <% unless logged_in? %>
+            <li><%= link_to "ログイン", login_path %></li>
+            <li><%= link_to "ユーザー登録", new_user_path %></li>
+          <% end %>
+          <li><%= link_to t('menu.index'), books_path %></li>
+          <li><%= link_to t('menu.post'), search_books_path %></li>
+          <li><%= link_to t('profiles.show.title'), profile_path %></li>
+          <% if logged_in? %>
+            <li><%= button_to "ログアウト", logout_path, method: :delete %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+    <div class="navbar-end hidden lg:flex">
+      <ul class="menu menu-horizontal p-0 mr-0">
         <% unless logged_in? %>
           <li><%= link_to "ログイン", login_path %></li>
           <li><%= link_to "ユーザー登録", new_user_path %></li>
         <% end %>
         <li><%= link_to t('menu.index'), books_path %></li>
         <li><%= link_to t('menu.post'), search_books_path %></li>
-        <li><%= link_to t('profiles.show.title'), profile_path, class: 'dropdown-item' %></li>
+        <li><%= link_to t('profiles.show.title'), profile_path %></li>
         <% if logged_in? %>
           <li><%= button_to "ログアウト", logout_path, method: :delete %></li>
         <% end %>
       </ul>
     </div>
   </div>
-</div>
+</header>


### PR DESCRIPTION
ログイン後のヘッダーを修正した。
メイン機能(投稿一覧、投稿作成、プロフィール)への導線をヘッダーに入れた。
左上はアプリのタイトルにしてtopページに遷移するようにした。