### PR TITLE
add: 投稿詳細画面の作者名から、その作者の作品一覧に遷移する機能の追加

### DIFF
--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -9,7 +9,10 @@
       </div>
       <%= link_to '作品を購入する', @book.info_link, target: :_blank, rel: "noopener noreferrer", class: "bg-neutral hover:bg-accent text-secondary text-center font-bold w-1/3 mx-auto mt-3 py-2 border rounded" %>
       <div class="card-body text-primary">
-        <p class="card-text font-bold flex justify-center">著者: <%= @book.authors.pluck(:name).join(', ')&.truncate(20) %></p>
+        <p class="card-text font-bold flex justify-center">
+          <% @book.authors.each do |author| %>
+            <%= link_to author.name, books_path(author_id: author.id), class: "link-success" %>
+          <% end %></p>
         <p class="card-text flex justify-center">出版日: <%= @book.published_date %></p>
         <p class="card-text flex justify-center">--舞台--</p>
         <p class="card-text flex justify-center"><%= @area[@book.country.area_id - 1] %></p>


### PR DESCRIPTION
投稿詳細画面の作者名をクリックすると、その作者の作品一覧画面に遷移するように変更した。