### PR TITLE
add: 投稿作成画面の3つのセレクトボックスを連動させた

### DIFF
--- a/app/javascript/packs/area_select.js
+++ b/app/javascript/packs/area_select.js
@@ -1,5 +1,56 @@
 import $ from 'jquery'
+$(document).on('turbo:load', function() {
+  //復活させるダミーのcountryのセレクトボックス
+  let defaultCountrySelect = `<div id="country"><div class="field"><div class="form-group"><select name="country", class="form-control border border-gray-300 rounded-md p-2 mb-3">
+  <option value>---</option>
+  </select></div></div></div>`;
+  //復活させるダミーのprefectureのセレクトボックス
+  let defaultPrefectureSelect = `<div id="prefecture"><div class="field"><div class="form-group"><select name="prefecture", class="form-control border border-gray-300 rounded-md p-2 mb-3">
+  <option value>都道府県を選択 (日本のみ)</option>
+  </select></div></div></div>`;
+//countryの処理
+$(document).on('change', '#book_area_id', function() {
+  let areaVal = $('#book_area_id').val();
+  //areaが変更されてvalueに値が入った場合の処理
+  if (areaVal !== "") {
+    let selectedTemplate = $(`#country_${areaVal}`); //呼び出すtemplateのidセット
+    $('#country').remove(); //デフォルト表示用のcountryを削除
+    $('#prefecture').remove(); //デフォルト表示用のprefectureを削除
+    $("#selected_country").remove(); //前に選択したcountryがある場合に削除
+    $("#selected_prefecture").remove();  //前に選択したprefectureがある場合に削除（これがないと、country, prefectureが選択された状態で、areaが変更された場合にprefectureが残ってしまう。）
+    $('#country_insert_point').after(selectedTemplate.html()); //areaに紐づいたcountryセレクトを追加
+    $('#prefecture_insert_point').after(defaultPrefectureSelect); //デフォルト表示のprefectureを追加
+  }else {
+    //親要素のセレクトボックスが変更されてvalueに値が入っていない場合（include_blankの部分を選択している場合）
+    $("#selected_country").remove();//前に選択したcountryがある場合に削除
+    $("#selected_prefecture").remove(); //前に選択したprefectureがある場合に削除
+    $('#country').remove();//デフォルト表示用のcountryを削除
+    $('#prefecture').remove(); //デフォルト表示用のprefectureを削除
+    $('#prefecture_insert_point').after(defaultCOuntrySelect); //デフォルト表示のcountryを追加
+    $('#prefecture_insert_point').after(defaultPrefectureSelect); //デフォルト表示のprefectureを追加
+  };
+});
+//prefectureの処理
+$(document).on('change', '#book_country_id', function() {
+  let areaVal = $('#book_country_id').val();
+  //親要素のセレクトボックスが変更されてvalueに値が入った場合の処理
+  if (areaVal !== "") {
+    let selectedTemplate = $(`#prefecture_${areaVal}`);
+   //デフォルトで入っていた子要素のセレクトボックスを削除
+  $("#selected_prefecture").remove();//前に選択したprefectureがある場合に削除
+   $('#prefecture').remove(); //デフォルト表示のprefectureを追加
+   // $('#before_country_select_box').remove();
+   $('#prefecture_insert_point').after(selectedTemplate.html()); //countryに紐づいたprefectureセレクトを追加
+  }else {
+  $('#prefecture').remove();
+   $("#selected_prefecture").remove(); //前に選択したprefectureを削除
+   $('#prefecture_insert_point').after(defaultPrefectureSelect); //デフォルト表示のprefectureを追加
+  };
+});
 
+});
+
+/*
 $(document).on('turbo:load', function() {
   //HTMLが読み込まれた時の処理
   let areaVal = $('#book_area_id').val();
@@ -30,3 +81,4 @@ $(document).on('turbo:load', function() {
     };
   });
 });
+*/

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -21,22 +21,70 @@
         <%= f.text_area :body, class: 'block w-1/2 rounded-md border border-gray-300 p-2', rows: 5, placeholder: '5文字以上で入力してください' %>
       </div>
       <div class="mb-3 font-semibold text-primary"><p>本の舞台を選択してください</p></div>
+      <!--div class="flex flex-col">
+        <%#= f.collection_select :area_id, Area.all, :id, :name, { include_blank: "エリアを選択" }, class: 'border border-gray-300 rounded-md w-40 p-2 mb-3' %>
+      </div>
+      <div>
+        <%#= f.select :country_id, [], { include_blank: "国を選択" }, class: 'border border-gray-300 w-40 rounded-md p-2' %>
+      </div>
+      <div class="mb-3">
+        <%# Area.all.each do |area| %>
+          <template id="country-of-area<%#= area.id %>">
+            <%#= f.collection_select :country_id, area.countries, :id, :name, { include_blank: "国を選択" }, class: 'border border-gray-300 w-40 rounded-md p-2' %>
+          </template>
+        <%# end %>
+      </div>
+      <div class="mb-5" id="prefecture-select-form">
+        <%#= f.select :prefecture_id, @prefecture, { include_blank: "都道府県を選択" } , class: 'border border-gray-300 rounded-md p-2', id: 'prefecture' %>
+      </div-->
+      <!--3つ連動 -->
       <div class="flex flex-col">
         <%= f.collection_select :area_id, Area.all, :id, :name, { include_blank: "エリアを選択" }, class: 'border border-gray-300 rounded-md w-40 p-2 mb-3' %>
       </div>
-      <div>
-        <%= f.select :country_id, [], { include_blank: "国を選択" }, class: 'border border-gray-300 w-40 rounded-md p-2' %>
+      <!-- countryが差し込ませるポイントを指定するために追加　※１ -->
+      <div id="country_insert_point"></div>
+      <!-- -----------EDIT時、countryのダミー表示の切替 ※２--->
+      <div id="country">
+        <div class="field">
+          <% if @countries.blank? %>
+            <%= f.select :country_id, [], { include_blank: "国を選択" }, class: 'border border-gray-300 w-40 rounded-md p-2 mb-3' %>
+          <% else %>
+            <%= f.collection_select :country_id, @countries, :id, :name, { include_blank: "国を選択", prompt: false }, class: 'border border-gray-300 w-40 rounded-md p-2 mb-3' %>
+          <% end %>
+        </div>
       </div>
-      <div class="mb-3">
-        <% Area.all.each do |area| %>
-          <template id="country-of-area<%= area.id %>">
-            <%= f.collection_select :country_id, area.countries, :id, :name, { include_blank: "国を選択" }, class: 'border border-gray-300 w-40 rounded-md p-2' %>
+      <!-- prefectureが差し込ませるポイントを指定するために追加 -->
+      <div id="prefecture_insert_point"></div>
+      <!-- -----------EDIT時、prefectureのダミー表示の切替 --->
+      <div id="prefecture">
+        <div class="field ">
+            <% if @prefectures.blank?  %>
+              <%= f.select :prefecture_id, [], { include_blank: "都道府県を選択 (日本のみ)" }, class: 'border border-gray-300 w-60 rounded-md p-2 mb-3' %>
+            <% else %>
+              <%= f.collection_select :prefecture_id, @prefectures, :id, :name, { include_blank: "都道府県を選択 (日本のみ)", prompt: false }, class: 'border border-gray-300 w-60 rounded-md p-2 mb-3' %>
+            <% end %>
+        </div>
+      </div>
+      <!-- -----------countryのtemplateを作成 ※3---------------------- -->
+      <% Area.all.each do |area| %>
+        <template id="country_<%= area.id %>"><!-- このidをもとに呼び出される-->
+          <div id="selected_country">
+            <div class="field" >
+              <%= f.collection_select :country_id, area.countries, :id, :name, { include_blank: "国を選択", prompt: false }, class: 'border border-gray-300 w-40 rounded-md p-2 mb-3' %>
+            </div>
+          </div>
+        </template>
+        <!-- -----------countryのtemplate作成途中に、prefectureのtemplateを作成を挟む※4---------------------- -->
+        <% area.countries.each do |country| %>
+          <template id="prefecture_<%= country.id %>"><!-- このidをもとに呼び出される-->
+            <div id="selected_prefecture">
+              <div class="field" >
+                <%= f.collection_select :prefecture_id, country.prefectures, :id, :name, { include_blank: "都道府県を選択 (日本のみ)", prompt: false }, class: 'border border-gray-300 w-60 rounded-md p-2 mb-3' %>
+              </div>
+            </div>
           </template>
         <% end %>
-      </div>
-      <div class="mb-5" id="prefecture-select-form">
-        <%= f.select :prefecture_id, @prefecture, { include_blank: "都道府県を選択" } , class: 'border border-gray-300 rounded-md p-2', id: 'prefecture' %>
-      </div>
+      <% end %>
       <%= f.hidden_field :title, value: @volume_info[:title] %>
       <%= f.hidden_field :published_date, value: @volume_info[:publishedDate] %>
       <%= f.hidden_field :info_link, value: @volume_info[:infoLink] %>


### PR DESCRIPTION
投稿作成画面の舞台を選択する3つ(エリア、国、都道府県)のセレクトボックスをJavaScriptを使用し連動させた。
参考にした記事
https://qiita.com/YuKiO-OO/items/d8e9cadb96737d96aa2d