### PR TITLE
add: 検索ボックス3つを連動させた

### DIFF
--- a/app/javascript/packs/area_search.js
+++ b/app/javascript/packs/area_search.js
@@ -1,6 +1,58 @@
 import $ from 'jquery'
-//$("#hoge").css("color","red")
 
+$(document).on('turbo:load', function() {
+  //復活させるダミーのcountryのセレクトボックス
+  let defaultCountrySelect = `<div id="country"><div class="field"><div class="form-group"><select name="country", class="text-primary border border-gray-300 rounded-md mb-2 ml-3 w-50 p-3">
+  <option value>---</option>
+  </select></div></div></div>`;
+  //復活させるダミーのprefectureのセレクトボックス
+  let defaultPrefectureSelect = `<div id="q_prefecture_id_eq"><div class="field"><div class="form-group"><select name="prefecture", class="text-primary border border-gray-300 rounded-md mb-2 ml-3 w-50 p-3">
+  <option value>都道府県 (日本のみ)</option>
+  </select></div></div></div>`;
+//countryの処理
+$(document).on('change', '#q_country_area_id_eq', function() {
+  let areaVal = $('#q_country_area_id_eq').val();
+  //areaが変更されてvalueに値が入った場合の処理
+  if (areaVal !== "") {
+    let selectedTemplate = $(`#country_${areaVal}`); //呼び出すtemplateのidセット
+    $('#q_country_id_eq').remove(); //デフォルト表示用のcountryを削除
+    $('#q_prefecture_id_eq').remove(); //デフォルト表示用のprefectureを削除
+    $("#selected_country").remove(); //前に選択したcountryがある場合に削除
+    $("#selected_prefecture").remove();  //前に選択したprefectureがある場合に削除（これがないと、country, prefectureが選択された状態で、areaが変更された場合にprefectureが残ってしまう。）
+    $('#country_insert_point').after(selectedTemplate.html()); //areaに紐づいたcountryセレクトを追加
+    $('#prefecture_insert_point').after(defaultPrefectureSelect); //デフォルト表示のprefectureを追加
+  }else {
+    //親要素のセレクトボックスが変更されてvalueに値が入っていない場合（include_blankの部分を選択している場合）
+    $("#selected_country").remove();//前に選択したcountryがある場合に削除
+    $("#selected_prefecture").remove(); //前に選択したprefectureがある場合に削除
+    $('#q_country_id_eq').remove();//デフォルト表示用のcountryを削除
+    $('#q_prefecture_id_eq').remove(); //デフォルト表示用のprefectureを削除
+    $('#prefecture_insert_point').after(defaultCOuntrySelect); //デフォルト表示のcountryを追加
+    $('#prefecture_insert_point').after(defaultPrefectureSelect); //デフォルト表示のprefectureを追加
+  };
+});
+//prefectureの処理
+$(document).on('change', '#q_country_id_eq', function() {
+  let areaVal = $('#q_country_id_eq').val();
+  //親要素のセレクトボックスが変更されてvalueに値が入った場合の処理
+  if (areaVal !== "") {
+    let selectedTemplate = $(`#prefecture_${areaVal}`);
+   //デフォルトで入っていた子要素のセレクトボックスを削除
+  $("#selected_prefecture").remove();//前に選択したprefectureがある場合に削除
+   $('#q_prefecture_id_eq').remove(); //デフォルト表示のprefectureを追加
+   // $('#before_country_select_box').remove();
+   $('#prefecture_insert_point').after(selectedTemplate.html()); //countryに紐づいたprefectureセレクトを追加
+  }else {
+  $('#q_prefecture_id_eq').remove();
+   $("#selected_prefecture").remove(); //前に選択したprefectureを削除
+   $('#prefecture_insert_point').after(defaultPrefectureSelect); //デフォルト表示のprefectureを追加
+  };
+});
+
+});
+
+
+/*
 $(document).on('turbo:load', function() {
   //HTMLが読み込まれた時の処理
   let areaVal = $('#q_country_area_id_eq').val();
@@ -31,3 +83,4 @@ $(document).on('turbo:load', function() {
     };
   });
 });
+*/

--- a/app/views/books/_search_form.html.erb
+++ b/app/views/books/_search_form.html.erb
@@ -1,0 +1,52 @@
+<%= search_form_for q do |f| %>
+  <%#= f.collection_select :country_area_id_eq, Area.where(id: Book.all.map{ |a| a.country.area_id }), :id, :name, { include_blank: "エリア" }, {class: 'text-primary border border-gray-300 rounded-md mb-2 ml-3 w-40 p-2'} %>
+  <%#= f.select :country_id_eq, [], { include_blank: "国" }, class: 'text-primary border border-gray-300 w-40 rounded-md mb-2 ml-3 w-40 p-2' %>
+  <%# Area.where(id: Book.all.map{ |a| a.country.area_id }).each do |area| %>
+    <!--template id="country-area<%#= area.id %>">
+      <%#= f.collection_select :country_id_eq, area.countries.where(id: Book.all.map{ |a| a.country.id }), :id, :name, { include_blank: "国" }, class: 'text-primary border border-gray-300 w-40 rounded-md mb-2 ml-3 w-40 p-2' %>
+    </template-->
+  <%# end %>
+  <%#= f.collection_select :prefecture_id_eq, Prefecture.where(id: Book.all.map{ |b| b.prefecture_id }), :id, :name, {include_blank: '都道府県'}, {class: "text-primary border border-gray-300 rounded-md mb-2 ml-3 w-40 p-2"} %>
+  <%#= f.submit t('defaults.search'), class: 'btn w-40 ml-3 mb-2 rounded text-secondary' %>
+  <!--3つ連動 -->
+  <div class="flex">
+    <%= f.collection_select :country_area_id_eq, Area.where(id: Book.all.map{ |a| a.country.area_id }), :id, :name, { include_blank: "エリア" }, class: 'text-primary border border-gray-300 rounded-md mb-2 ml-3 w-40 p-2' %>
+    <!-- countryが差し込ませるポイントを指定するために追加　※１ -->
+    <div id="country_insert_point"></div>
+    <!-- -----------EDIT時、countryのダミー表示の切替 ※２--->
+    <div id="country">
+      <% if @countries.blank? %>
+        <%= f.select :country_id_eq, [], { include_blank: "国" }, class: 'text-primary border border-gray-300 rounded-md mb-2 ml-3 w-40 p-3' %>
+      <% else %>
+        <%= f.collection_select :country_id_eq, @countries, :id, :name, { include_blank: "国", prompt: false }, class: 'text-primary border border-gray-300 rounded-md mb-2 ml-3 w-40 p-3' %>
+      <% end %>
+    </div>
+    <!-- prefectureが差し込ませるポイントを指定するために追加 -->
+    <div id="prefecture_insert_point"></div>
+    <!-- -----------EDIT時、prefectureのダミー表示の切替 --->
+    <div id="prefecture">
+      <% if @prefectures.blank?  %>
+        <%= f.select :prefecture_id_eq, [], { include_blank: "都道府県 (日本のみ)" }, class: 'text-primary border border-gray-300 rounded-md mb-2 ml-3 w-50 p-3' %>
+      <% else %>
+        <%= f.collection_select :prefecture_id_eq, @prefectures, :id, :name, { include_blank: "都道府県 (日本のみ)", prompt: false }, class: 'text-primary border border-gray-300 rounded-md mb-2 ml-3 w-50 p-3' %>
+      <% end %>
+    </div>
+    <!-- -----------countryのtemplateを作成 ※3---------------------- -->
+    <% Area.all.each do |area| %>
+      <template id="country_<%= area.id %>"><!-- このidをもとに呼び出される-->
+        <div id="selected_country">
+          <%= f.collection_select :country_id_eq, area.countries, :id, :name, { include_blank: "国", prompt: false }, class: 'text-primary border border-gray-300 rounded-md mb-2 ml-3 w-40 p-3' %>
+        </div>
+      </template>
+      <!-- -----------countryのtemplate作成途中に、prefectureのtemplateを作成を挟む※4---------------------- -->
+      <% area.countries.each do |country| %>
+        <template id="prefecture_<%= country.id %>"><!-- このidをもとに呼び出される-->
+          <div id="selected_prefecture">
+            <%= f.collection_select :prefecture_id_eq, country.prefectures, :id, :name, { include_blank: "都道府県 (日本のみ)", prompt: false }, class: 'text-primary border border-gray-300 rounded-md mb-2 ml-3 w-50 p-3' %>
+          </div>
+        </template>
+      <% end %>
+    <% end %>
+    <%= f.submit t('defaults.search'), class: 'btn w-40 ml-3 mb-2 rounded text-secondary' %>
+  </div>
+<% end %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,18 +1,9 @@
 <% content_for(:title, t('.title')) %>
 <% breadcrumb :books %>
 <div class="container mx-auto px-3 my-3">
+  
   <!-- 検索フォーム -->
-  <%= search_form_for @q do |f| %>
-    <%= f.collection_select :country_area_id_eq, Area.where(id: Book.all.map{ |a| a.country.area_id }), :id, :name, { include_blank: "エリア" }, {class: 'text-primary border border-gray-300 rounded-md mb-2 ml-3 w-40 p-2'} %>
-    <%= f.select :country_id_eq, [], { include_blank: "国" }, class: 'text-primary border border-gray-300 w-40 rounded-md mb-2 ml-3 w-40 p-2' %>
-    <% Area.where(id: Book.all.map{ |a| a.country.area_id }).each do |area| %>
-      <template id="country-area<%= area.id %>">
-        <%= f.collection_select :country_id_eq, area.countries.where(id: Book.all.map{ |a| a.country.id }), :id, :name, { include_blank: "国" }, class: 'text-primary border border-gray-300 w-40 rounded-md mb-2 ml-3 w-40 p-2' %>
-      </template>
-    <% end %>
-    <%= f.collection_select :prefecture_id_eq, Prefecture.where(id: Book.all.map{ |b| b.prefecture_id }), :id, :name, {include_blank: '都道府県'}, {class: "text-primary border border-gray-300 rounded-md mb-2 ml-3 w-40 p-2"} %>
-    <%= f.submit t('defaults.search'), class: 'btn w-40 ml-3 mb-2 rounded text-secondary' %>
-  <% end %>
+  <%= render 'books/search_form', q: @q %>
   <!-- 投稿一覧 -->
   <% if @books.present? %>
     <div class="flex flex-wrap">


### PR DESCRIPTION
投稿一覧画面にある検索ボックスを、可読性を上げるために部分テンプレート化した。
さらに、舞台の検索ボックス3点(エリア、国、都道府県)をJavaScriptで連動させた。

参考にした記事
https://qiita.com/YuKiO-OO/items/d8e9cadb96737d96aa2d