### PR TITLE
【質問】マップから投稿を絞り込みたい

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,7 +1,172 @@
 <% content_for(:title, t('.title')) %>
 <% breadcrumb :books %>
 <div class="container mx-auto px-3 my-3">
-  
+  <div id="regions_div" class="mx-auto" style="width: 900px; height: 500px;"></div>
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<script>
+    google.charts.load('current', {
+        'packages':[
+            'geochart'
+        ],
+        'mapsApiKey': ''
+    });
+
+    google.charts.setOnLoadCallback(drawRegionsMap);
+
+    // 国がクリックされたら、国名コードをGETパラメータにして投稿一覧ページへ送る
+    function selectHandler(reg) {
+        window.location.href = '/books?q%5Bcountry_id_eq%5D=' + 'Country.where(country_code: reg.region).id' + '5&q%5Bcountry_code_eq%5D=' + reg.region;
+    }
+
+    function drawRegionsMap() {
+        // 国名コードと国の表示名の配列をここで読み込んでください。
+        const codes = [
+            ["Country", "Name"],
+            ["JP", "日本"],
+            ["KR", "韓国"],
+            ["KP", "北朝鮮"],
+            ["TW", "台湾"],
+            ["CN", "中国"],
+            ["HK", "香港"],
+            ["TL", "東ティモール"],
+            ["MO", "マカオ"],
+            ["IN", "インド"],
+            ["ID", "インドネシア"],
+            ["KH", "カンボジア"],
+            ["SG", "シンガポール"],
+            ["LK", "スリランカ"],
+            ["TH", "タイ"],
+            ["NP", "ネパール"],
+            ["PK", "パキスタン"],
+            ["BD", "バングラデシュ"],
+            ["PH", "フィリピン"],
+            ["BT", "ブータン"],
+            ["BN", "ブルネイ"],
+            ["VN", "ベトナム"],
+            ["MY", "マレーシア"],
+            ["MM", "ミャンマー"],
+            ["MV", "モルディブ"],
+            ["MN", "モンゴル"],
+            ["LA", "ラオス"],
+            ["AU", "オーストラリア"],
+            ["CK", "クック諸島"],
+            ["WS", "サモア"],
+            ["SC", "セイシェル"],
+            ["SB", "ソロモン諸島"],
+            ["TV", "ツバル"],
+            ["TO", "トンガ"],
+            ["NC", "ニューカレドニア"],
+            ["NZ", "ニュージーランド"],
+            ["PG", "パプアニューギニア"],
+            ["PW", "パラオ"],
+            ["FJ", "フィジー"],
+            ["US", "アメリカ"],
+            ["CA", "カナダ"],
+            ["AR", "アルゼンチン"],
+            ["CU", "キューバ"],
+            ["UY", "ウルグアイ"],
+            ["EC", "エクアドル"],
+            ["CR", "コスタリカ"],
+            ["CO", "コロンビア"],
+            ["JM", "ジャマイカ"],
+            ["CL", "チリ"],
+            ["PA", "パナマ"],
+            ["PY", "パラグアイ"],
+            ["BR", "ブラジル"],
+            ["VE", "ベネズエラ"],
+            ["PE", "ペルー"],
+            ["BO", "ボリビア"],
+            ["MX", "メキシコ"],
+            ["IS", "アイスランド"],
+            ["IE", "アイルランド"],
+            ["AL", "アルバニア"],
+            ["AM", "アルメニア"],
+            ["GB", "イギリス"],
+            ["IT", "イタリア"],
+            ["UA", "ウクライナ"],
+            ["UZ", "ウズベキスタン"],
+            ["EE", "エストニア"],
+            ["AT", "オーストリア"],
+            ["NL", "オランダ"],
+            ["KZ", "カザフスタン"],
+            ["GR", "ギリシャ"],
+            ["GL", "グリーンランド"],
+            ["HR", "クロアチア"],
+            ["GE", "ジョージア"],
+            ["CH", "スイス"],
+            ["SE", "スウェーデン"],
+            ["ES", "スペイン"],
+            ["SK", "スロバキア"],
+            ["SI", "スロベニア"],
+            ["CZ", "チェコ"],
+            ["DK", "デンマーク"],
+            ["DE", "ドイツ"],
+            ["NO", "ノルウェー"],
+            ["VA", "バチカン"],
+            ["FI", "フィンランド"],
+            ["FR", "フランス"],
+            ["BG", "ブルガリア"],
+            ["BE", "ベルギー"],
+            ["PL", "ポーランド"],
+            ["PT", "ポルトガル"],
+            ["MT", "マルタ"],
+            ["MC", "モナコ"],
+            ["ME", "モンテネグロ"],
+            ["LV", "ラトビア"],
+            ["LT", "リトアニア"],
+            ["RO", "ルーマニア"],
+            ["RU", "ロシア"],
+            ["AF", "アフガニスタン"],
+            ["AE", "アラブ首長国連邦"],
+            ["IL", "イスラエル"],
+            ["IQ", "イラク"],
+            ["IR", "イラン"],
+            ["OM", "オマーン"],
+            ["QA", "カタール"],
+            ["KW", "クウェート"],
+            ["SA", "サウジアラビア"],
+            ["SY", "シリア"],
+            ["TR", "トルコ"],
+            ["JO", "ヨルダン"],
+            ["LB", "レバノン"],
+            ["DZ", "アルジェリア"],
+            ["AO", "アンゴラ"],
+            ["UG", "ウガンダ"],
+            ["EG", "エジプト"],
+            ["ET", "エチオピア"],
+            ["GH", "ガーナ"],
+            ["CM", "カメルーン"],
+            ["GN", "ギニア"],
+            ["KE", "ケニア"],
+            ["CI", "コートジボワール"],
+            ["ZM", "ザンビア"],
+            ["ZW", "ジンバブエ"],
+            ["SD", "スーダン"],
+            ["SO", "ソマリア"],
+            ["TZ", "タンザニア"],
+            ["TN", "チュニジア"],
+            ["NG", "ナイジェリア"],
+            ["NA", "ナミビア"],
+            ["BW", "ボツワナ"],
+            ["MG", "マダガスカル"],
+            ["ZA", "南アフリカ"],
+            ["SS", "南スーダン"],
+            ["MU", "モーリシャス"],
+            ["MR", "モーリタニア"],
+            ["MA", "モロッコ"],
+            ["LY", "リビア"],
+            ["RW", "ルワンダ"]
+        ];
+        const data = google.visualization.arrayToDataTable(codes);
+        const options = {
+            defaultColor:'#82AAE3',
+        };
+        const chart = new google.visualization.GeoChart(document.getElementById('regions_div'));
+
+        google.visualization.events.addListener(chart, 'regionClick', selectHandler);
+        chart.draw(data, options);
+    }
+</script>
   <!-- 検索フォーム -->
   <%= render 'books/search_form', q: @q %>
   <!-- 投稿一覧 -->

--- a/db/fixtures/01_country.rb
+++ b/db/fixtures/01_country.rb
@@ -1,9 +1,9 @@
 Country.seed(:id, [
-  { id: 1, name: '日本', area_id: 1 },
+  { id: 1, name: '日本', area_id: 1, country_code: "JP" },
   { id: 2, name: '韓国', area_id: 1 },
   { id: 3, name: '北朝鮮', area_id: 1 },
   { id: 4, name: '台湾', area_id: 1 },
-  { id: 5, name: '中国', area_id: 1 },
+  { id: 5, name: '中国', area_id: 1, country_code: "CN" },
   { id: 6, name: '香港', area_id: 1 },
   { id: 7, name: '東ティモール', area_id: 1 },
   { id: 8, name: 'マカオ', area_id: 1 },

--- a/db/migrate/20230210040003_add_code_to_countries.rb
+++ b/db/migrate/20230210040003_add_code_to_countries.rb
@@ -1,0 +1,5 @@
+class AddCodeToCountries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :countries, :country_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_29_073544) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_10_040003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,6 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_29_073544) do
     t.bigint "area_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "country_code"
     t.index ["area_id"], name: "index_countries_on_area_id"
   end
 


### PR DESCRIPTION
**質問内容・実現したいこと**
投稿一覧画面にマップを導入し、マップ上の国をクリックすると、その国が舞台として登録されている投稿作品を一覧表示したいです。

**経緯**
[Geo chart](https://developers.google.com/chart/interactive/docs/gallery/geochart?hl=ja)を使用して投稿一覧にマップを表示しましたが、投稿された本の舞台(国)と紐付ける方法がわかりませんでした。
Geo chartのマップを表示するコードでは、国を表示するためにstring型の[国コード](https://www.asahi-net.or.jp/~ax2s-kmtn/ref/iso3166-1.html)("JP", "CN"等)を使用しており、
投稿用のbooksテーブルでは、Countriesテーブルから引っ張ってきたcountry_idを舞台の国を登録するカラムとして使用しています。
Geo chartのマップの国コードと投稿作品の国を紐付けるために、string型の国コード("JP", "CN"等)を試しにCountriesテーブルにcountry_codeカラムとして追加しました。
その後、Geo chartのマップを表示しているJavaScriptの部分に、「国がクリックされたら、国名コードをGETパラメータにして投稿一覧ページへ送る」というようなコードを書けば目的の動きになるのではないかと思い、ransackで作成した検索ボックスで検索した際のURLを参考に書いてみましたが、おそらくコードが間違っており上手くいきませんでした。
(ransackの検索ボックスで検索した時のURL↓)
http://localhost:3000/books?q%5Bcountry_area_id_eq%5D=1&q%5Bcountry_id_eq%5D=1&q%5Bprefecture_id_eq%5D=&commit=%E6%A4%9C%E7%B4%A2

**助言いただきたいこと**
 - そもそも「マップから作品を探す機能」を実装するために、このような流れで実現できるのかをアドバイスいただきたいです
 - この流れで実装できそうであれば、「国がクリックされたら、国名コードをGETパラメータにして投稿一覧ページへ送る」というコードを書く方法を教えていただきたいです

**マップの表示で参考にした記事**
https://webty.jp/staffblog/production/post-4346/

**該当のソースコード**
views/books/index.html.erb
```
<div id="regions_div" class="mx-auto" style="width: 900px; height: 500px;"></div>
<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
<script>
    google.charts.load('current', {
        'packages':[
            'geochart'
        ],
        'mapsApiKey': '' //APIキーを入れる
    });

    google.charts.setOnLoadCallback(drawRegionsMap);

    // 国がクリックされたら、国名コードをGETパラメータにして投稿一覧ページへ送る
    function selectHandler(reg) {
        window.location.href = '/books?q%5Bcountry_id_eq%5D=' + 'Country.where(country_code: reg.region).idと同じ意味の変数を入れたい' + '5&q%5Bcountry_code_eq%5D=' + reg.region;
    }

    function drawRegionsMap() {
        // 国名コードと国の表示名の配列をここで読み込んでください。
        const codes = [
            ["Country", "Name"],
            ["JP", "日本"],
            ["KR", "韓国"],
            ["KP", "北朝鮮"],
            ["TW", "台湾"],
            ["CN", "中国"],
            ...省略...
            ["RW", "ルワンダ"]
        ];
        const data = google.visualization.arrayToDataTable(codes);
				// 色を指定する部分(投稿データがある国は青色、ない国は白色で分けたい)
        const options = {
            defaultColor:'#82AAE3',
        };
        const chart = new google.visualization.GeoChart(document.getElementById('regions_div'));

        google.visualization.events.addListener(chart, 'regionClick', selectHandler);
        chart.draw(data, options);
    }
</script>
```
Countriesテーブルのseedファイルの一部(試しに日本と中国のみcountry_codeカラムのデータを入れた)
```
Country.seed(:id, [
  { id: 1, name: '日本', area_id: 1, country_code: "JP" },
  { id: 2, name: '韓国', area_id: 1 },
  { id: 3, name: '北朝鮮', area_id: 1 },
  { id: 4, name: '台湾', area_id: 1 },
  { id: 5, name: '中国', area_id: 1, country_code: "CN" },
```
**現時点で表示されたマップ**
https://i.gyazo.com/9f43dd08f27365eecd50695f4ec26e7f.png