### PR TITLE
fix:リロードしないとJSが読み込まれないエラーを解消

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -8,13 +8,13 @@
   <div class="my-5">
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script>
-        google.charts.load('current', {
-            'packages':[
-                'geochart'
-            ],
-            'mapsApiKey': '<%= ENV['GOOGLE_MAP_API'] %>'
-        });
-        
+      document.addEventListener("turbo:load", function() { 
+          google.charts.load('current', {
+              'packages':[
+                  'geochart'
+              ],
+              'mapsApiKey': '<%= ENV['GOOGLE_MAP_API'] %>'
+          });
         // モデルをJSON.parseする
         const modeljson_parse = (item) => {
           item = JSON.stringify(item);  // JSをjsonに置換
@@ -62,6 +62,7 @@
         }
 
         google.charts.setOnLoadCallback(drawRegionsMap);
+      });
     </script>
   </div>
   <!-- 検索フォーム -->


### PR DESCRIPTION
投稿一覧画面にJSで記述したマップ(Geo chart)が、画面遷移後に表示されず都度リロードしないといけなかったため、[こちらの記事](https://qiita.com/zenfumi/items/a92c0385d361e04fb014)を参考にしてJSの部分だけturboの設定を追加した。