### PR TITLE
fix:ログイン後にリロードしなければいけない問題の解消

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -3,7 +3,7 @@
   <div class="mx-auto w-full max-w-2xl">
     <div class="text-center text-2xl font-bold text-primary pb-3"><%= t('.title') %></div>
       <div class="bg-white card border-2 px-8 pt-8 pb-3 mb-3 rounded-lg">
-        <%= form_with url: login_path, local: true do |f| %>
+        <%= form_with url: login_path, data: { turbo: false } do |f| %>
           <%= f.label :email, User.human_attribute_name(:email), class: "label font-bold text-primary" %>
           <%= f.email_field :email, class: "w-full py-4 px-8 input input-bordered rounded", placeholder: "***@example.com" %>
           <%= f.label :password, User.human_attribute_name(:password), class: "label font-bold text-primary" %>


### PR DESCRIPTION
ログイン後に一度リロードしないと地図が表示されない問題を解消するために、ログイン画面のformに`data: { turbo: false }`を追加した。