### PR TITLE
fix:文字の配置の調整

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title')) %>
 <% breadcrumb :books %>
-<div class="text-primary text-center text-xl">
+<div class="text-primary text-center text-xl pt-2">
   <p>地図または検索ボックスから投稿を絞りこんでください</p>
 </div>
 <div class="container mx-auto my-3">


### PR DESCRIPTION
投稿一覧画面のパンくずと「地図または検索ボックスから投稿を絞りこんでください」という文言の間にスペースを増やした。