### PR TITLE
fix:パスワード設定文字数の変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_books, through: :bookmarks, source: :book
 
-  validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -10,9 +10,9 @@
         <%= f.label :email, class: "label font-bold text-primary" %>
         <%= f.email_field :email, class: "w-full py-4 px-8 input input-bordered rounded", placeholder: "例: ***@example.com" %>
         <%= f.label :password, class: "label font-bold text-primary" %>
-        <%= f.password_field :password,  class: "w-full py-4 px-8 input input-bordered rounded", placeholder: "例: password" %>
+        <%= f.password_field :password,  class: "w-full py-4 px-8 input input-bordered rounded", placeholder: "6文字以上で設定してください" %>
         <%= f.label :password_confirmation, class: "label font-bold text-primary" %>
-        <%= f.password_field :password_confirmation, class: "w-full py-4 px-8 input input-bordered rounded", placeholder: "例: password" %>
+        <%= f.password_field :password_confirmation, class: "w-full py-4 px-8 input input-bordered rounded", placeholder: "6文字以上で設定してください" %>
         <div class="py-4">
           <%= f.submit t('defaults.register'), class: "btn py-4 w-full rounded text-secondary" %>
         </div>


### PR DESCRIPTION
ユーザー登録のパスワードの文字数をセキュリティを上げるために「3文字以上」から「6文字以上」に変更した。