### PR TITLE
fix:文字の折り返し位置の調整

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,9 +1,10 @@
 <% content_for(:title, t('.title')) %>
 <% breadcrumb :books %>
-<div class="text-primary text-center text-xl pt-2">
-  <p>地図または検索ボックスから投稿を絞りこんでください</p>
+<div class="text-primary text-center text-xl whitespace-pre-wrap">
+  <p>地図または検索ボックスから
+  投稿を絞りこんでください</p>
 </div>
-<div class="container mx-auto my-3">
+<div class="container mx-auto mb-3">
   <div id="regions_div" class="mx-auto" style="max-width: 900px; width: 90%"></div>
   <div class="my-5">
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>


### PR DESCRIPTION
投稿一覧画面の「地図または検索ボックスから投稿を絞りこんでください」という文言が、スマホサイズでは、自然でない位置で折り返しされていたため、PCサイズでもスマホサイズでも文章の自然な区切りで折り返すよう変更した。